### PR TITLE
[BE 0.2.0] Add FeedController to enable the API /feed

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,41 @@
+{
+  "configurations": [
+    {
+      "type": "java",
+      "name": "CodeLens (Launch) - FeedReaderTest",
+      "request": "launch",
+      "mainClass": "com.aggregator.utils.FeedReaderTest",
+      "projectName": "backend"
+    },
+    {
+      "type": "java",
+      "name": "Spring Boot-DemoApplication<backend>",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole",
+      "mainClass": "com.aggregator.backend.DemoApplication",
+      "projectName": "backend",
+      "args": ""
+    },
+    {
+      "type": "java",
+      "name": "Spring Boot-DemoApplication<backend>",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole",
+      "mainClass": "com.aggregator.DemoApplication",
+      "projectName": "backend",
+      "args": ""
+    },
+    {
+      "type": "java",
+      "name": "Spring Boot-AggregatorApplication<backend>",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole",
+      "mainClass": "com.aggregator.AggregatorApplication",
+      "projectName": "backend",
+      "args": ""
+    }
+  ]
+}

--- a/articles.rss
+++ b/articles.rss
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+<channel>
+	<title>Eclipse and Java Information</title>
+	<link>https://www.vogella.com/</link>
+	<description>Eclipse and Java Information</description>
+	<language>en</language>
+	<copyright>Copyright hold by Lars Vogel</copyright>
+	<pubdate>Thu, 11 Jun 2020 10:31:08 -0300</pubdate>
+<item>
+	<title>RSSFeed</title>
+	<description>This is a description</description>
+	<link>https://www.vogella.com/tutorials/RSSFeed/article.html</link>
+	<author>nonsense@somewhere.de (Lars Vogel)</author>
+	<guid>https://www.vogella.com/tutorials/RSSFeed/article.html</guid>
+
+</item>
+
+</channel>
+</rss>

--- a/backend/src/main/java/com/aggregator/AggregatorApplication.java
+++ b/backend/src/main/java/com/aggregator/AggregatorApplication.java
@@ -1,13 +1,13 @@
-package com.aggregator.backend;
+package com.aggregator;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class DemoApplication {
+public class AggregatorApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(DemoApplication.class, args);
+		SpringApplication.run(AggregatorApplication.class, args);
 	}
 
 }

--- a/backend/src/main/java/com/aggregator/model/Feed.java
+++ b/backend/src/main/java/com/aggregator/model/Feed.java
@@ -1,0 +1,25 @@
+package com.aggregator.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Feed {
+  private final String title;
+  private final List<News> items = new ArrayList<News>();
+
+  public Feed(String title) {
+    this.title = title;
+  }
+
+  public List<News> getItems() {
+    return items;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void addItem(News item) {
+    this.items.add(item);
+  }
+}

--- a/backend/src/main/java/com/aggregator/model/Input.java
+++ b/backend/src/main/java/com/aggregator/model/Input.java
@@ -1,0 +1,12 @@
+package com.aggregator.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Input {
+  List<String> urls = new ArrayList<String>();
+
+  public List<String> getUrls() {
+    return urls;
+  }
+}

--- a/backend/src/main/java/com/aggregator/model/News.java
+++ b/backend/src/main/java/com/aggregator/model/News.java
@@ -1,0 +1,34 @@
+package com.aggregator.model;
+
+public class News {
+  private final String title;
+  private final String link;
+  private final String date;
+
+  public News(String title, String link, String date) {
+    this.title = title;
+    this.link = link;
+    this.date = date;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public String getLink() {
+    return link;
+  }
+
+  public String getDate() {
+    return date;
+  }
+
+  @Override
+  public String toString() {
+    return "--------------------\n" +
+      "Title: " + title + ".\n" + 
+      "Link: " + link + ".\n" + 
+      "Date: " + date + ".\n" +
+      "--------------------\n";
+  }
+}

--- a/backend/src/main/java/com/aggregator/resource/FeedController.java
+++ b/backend/src/main/java/com/aggregator/resource/FeedController.java
@@ -1,0 +1,25 @@
+package com.aggregator.resource;
+
+import java.util.List;
+
+import com.aggregator.model.Feed;
+import com.aggregator.model.Input;
+import com.aggregator.service.FeedsService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class FeedController {
+
+  @Autowired
+  private FeedsService FeedsService;
+
+  @RequestMapping("/feed")
+  public List<Feed> getFeedsFromList(@Validated @RequestBody Input feedList) {
+    return FeedsService.findAll(feedList.getUrls());
+  }
+}

--- a/backend/src/main/java/com/aggregator/service/FeedsService.java
+++ b/backend/src/main/java/com/aggregator/service/FeedsService.java
@@ -1,0 +1,21 @@
+package com.aggregator.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.aggregator.model.Feed;
+import com.aggregator.utils.FeedReader;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class FeedsService {
+  public List<Feed> findAll(List<String> urls) {
+    List<Feed> feeds = new ArrayList<Feed>();
+    for(String url : urls) {
+      Feed feed = new FeedReader(url).getFeed();
+      feeds.add(feed);
+    }
+    return feeds;
+  }
+}

--- a/backend/src/main/java/com/aggregator/utils/FeedReader.java
+++ b/backend/src/main/java/com/aggregator/utils/FeedReader.java
@@ -1,0 +1,98 @@
+package com.aggregator.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.Characters;
+import javax.xml.stream.events.XMLEvent;
+
+import com.aggregator.model.News;
+import com.aggregator.model.Feed;
+
+public class FeedReader {
+  static final String TITLE = "title";
+  static final String LINK = "link";
+  static final String ITEM = "item";
+  static final String DATE = "pubDate";
+
+  final URL url;
+
+  public FeedReader(String feedUrl) {
+    try {
+      this.url = new URL(feedUrl);
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public Feed getFeed() {
+    Feed feed = null;
+    try {
+      boolean isFeedHeader = true;
+      String title = "";
+      String link = "";
+      String date = "";
+
+      XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+      InputStream in = read();
+      XMLEventReader eventReader = inputFactory.createXMLEventReader(in);
+
+      while (eventReader.hasNext()) {
+        XMLEvent event = eventReader.nextEvent();
+        if (event.isStartElement()) {
+          String localPart = event.asStartElement().getName().getLocalPart();
+          switch (localPart) {
+          case ITEM:
+            if (isFeedHeader) {
+              isFeedHeader = false;
+              feed = new Feed(title);
+            }
+            event = eventReader.nextEvent();
+            break;
+          case TITLE:
+            title = getCharacterData(event, eventReader);
+            break;
+          case LINK:
+            link = getCharacterData(event, eventReader);
+            break;
+          case DATE:
+            date = getCharacterData(event, eventReader);
+            break;
+          }
+        } else if (event.isEndElement()) {
+          if (event.asEndElement().getName().getLocalPart() == (ITEM)) {
+              News item = new News(title, link, date);
+              feed.addItem(item);
+              event = eventReader.nextEvent();
+              continue;
+          }
+        }
+      }
+    } catch (XMLStreamException e) {
+        throw new RuntimeException(e);
+    }
+    return feed;
+  }
+
+  private String getCharacterData(XMLEvent event, XMLEventReader eventReader) throws XMLStreamException {
+    String result = "";
+    event = eventReader.nextEvent();
+    if (event instanceof Characters) {
+        result = event.asCharacters().getData();
+    }
+    return result;
+  }
+
+  private InputStream read() {
+    try {
+        return url.openStream();
+    } catch (IOException e) {
+        throw new RuntimeException(e);
+    }
+  }
+}

--- a/backend/src/test/java/com/aggregator/AggregatorApplicationTests.java
+++ b/backend/src/test/java/com/aggregator/AggregatorApplicationTests.java
@@ -1,10 +1,10 @@
-package com.aggregator.backend;
+package com.aggregator;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class DemoApplicationTests {
+class AggregatorApplicationTests {
 
 	@Test
 	void contextLoads() {

--- a/backend/src/test/java/com/aggregator/utils/FeedReaderTest.java
+++ b/backend/src/test/java/com/aggregator/utils/FeedReaderTest.java
@@ -1,0 +1,13 @@
+package com.aggregator.utils;
+
+import com.aggregator.model.Feed;
+import com.aggregator.model.News;
+
+public class FeedReaderTest {
+  public static void main(String[] args) {
+    Feed feed = new FeedReader("https://www.wired.com/category/science/feed").getFeed();
+    for (News news : feed.getItems()) {
+      System.out.println(news);
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?
- Add first implementation of BE.
- Enables **`/feed`** route.

## How to test?
- Run Server Locally.
- With Postman send an POST with Body like `{ "urls": [feed_you_want] }` to **/feed**.
-  See the response.

Response:
![image](https://user-images.githubusercontent.com/39530109/84408845-064f2f00-abe3-11ea-98d2-67c4888ad0b8.png)

## Critical points
- No critical points.